### PR TITLE
Add Vcs* labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The following types of data are being considered:
  | URL         | Url with more information on the image|
  | Summary     | Short Description of the image|
  | Description | Detailed description of the image|
+ | VcsType    | The type of version control used by the container source. Generally one of git, hg, svn, bzr, cvs|
+ | VcsUrl     | URL of the version control repository|
+ | VcsRef     | A 'reference' within the version control repository; e.g. a git commit, or a subversion branch|
+
 
 3. Annotations with container configuration that is externally accessible, to clarify the extent to which a container image is a "black box". Rather than explicit fields, this is a pattern for the key (in likeness to an Object Identifiers (OID) or the Java package naming convention).
 


### PR DESCRIPTION
Add VcsType, VcsURL and VcsRef labels, used to describe where the image source can be obtained
from version control.

Discussed in issue #10.
