### PR TITLE
Adding DEBUG Label

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following types of data are being considered:
  | UNINSTALL   | Command to uninstall the image|
  | INSTALL     | Command to install the image|
  | STOP        | Command to execute before stopping container|
+ | DEBUG       | Command to run the image with debugging turned on|
 
 2. Labels Names used to describe the application/image
 


### PR DESCRIPTION
DEBUG can be used by developers who may want to change options
during testing ala

http://www.projectatomic.io/blog/2015/05/bugfix-container-software-in-place/

It can be used on a shipping container to allow a customer to restart
the container with debugging tools/messages enabled
