### PR TITLE
Removed the word 'required' from RUN, INSTALL and UNINSTALL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The following types of data are being considered:
 
  | Name        | Description                            |
  |-------------|----------------------------------------|
- | RUN         | Command required to run the image|
- | UNINSTALL   | Command Required to uninstall the image|
- | INSTALL     | Command Required to install the image|
+ | RUN         | Command to run the image|
+ | UNINSTALL   | Command to uninstall the image|
+ | INSTALL     | Command to install the image|
 
 2. Labels Names used to describe the application/image
 


### PR DESCRIPTION
If we want to require a tag, we should add a column and be
explicit about it.
