### PR TITLE
Add a changelog label

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,26 +42,27 @@ The following types of data are being considered:
  | vcs_type    | The type of version control used by the container source. Generally one of git, hg, svn, bzr, cvs|
  | vcs_url     | URL of the version control repository|
  | vcs_ref     | A 'reference' within the version control repository; e.g. a git commit, or a subversion branch|
- | authoritative_source | The  authoritative location in which the image is published|
+ | authoritative_source_url | The authoritative location in which the image is published|
  | distribution_scope  | Intended scope of distribution for image (see below for possible values)|
+ | changelog_url | URL of a page containing release notes for the image|
 
 3. Possible values of distribution_scope field
 
  |Name         | Description |
  |-------------|-------------|
  | private     | No public redistribution intended|
- | authoritative_source_only  | Redistribution only from the source listed in the 'authoritative_source' label|
+ | authoritative_source_only  | Redistribution only from the source listed in the 'authoritative_source_url' label|
  | restricted  | Redistribution only with permission|
  | public      | No redistribution limits beyond licenses|
 
 
 ## Details on Labels
 
-## authoritative_source 
+## `authoritative_source_url`
 * The authoritative location the image is published by the owner.
 * In combination with the 'name' label, this tells a user where to go and look for official updates and current versions of the image, regardless of the local tags.
 
-## distribution_scope
+## `distribution_scope`
 * The intended scope of distribution for the image.
 * Allows a user to define the intended scope of distribution. This addresses the end-user case of internal builds vs. public content and the use case of a vendor like Red Hat that provides content streams under subscription agreements - which is different from the license(s) of the image content.
-* In combination with the 'authoritative_source' and 'name' labels allows automatic redirect to the authoritative source.
+* In combination with the 'authoritative_source_url' and 'name' labels allows automatic redirect to the authoritative source.


### PR DESCRIPTION
The changelog label can be used to link to a pgae that would contain
release notes for the image.

Fixes #38.
