### PR TITLE
Require build-date to be in RFC 3339 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following types of data are being considered:
  | version     | Version of the image|
  | release     | Release Number for this version|
  | architecture| Architecture for the image|
- | build-date  | Date/Time image was built|
+ | build-date  | Date/Time image was built as [RFC 3339](https://tools.ietf.org/html/rfc3339) date-time|
  | vendor      | Owner of the image| 
  | url         | Url with more information on the image|
  | summary     | Short Description of the image|

--- a/vendor/redhat/labels.md
+++ b/vendor/redhat/labels.md
@@ -49,7 +49,7 @@ $authoritative-source[:PORT]/PRODUCT[$PRODUCTGEN][--$PLATFORMDIFFERENTIATOR]/REP
     * `public` No redistribution limits beyond licenses
   * For Red Hat product images this will be set to `"authoritative-source-only"`
 * `"build-date"`
-  * Date/Time image was built (Optional)
+  * Date/Time image was built as [RFC 3339](https://tools.ietf.org/html/rfc3339) date-time (Optional)
 * `"url"` (Optional)
   * Url with more information on the image
 * `"summary"` (Required)


### PR DESCRIPTION
The `build-date` label currently does not specify the format of the date. I suggest that we use RFC 3339, used by e.g. docker and kubernetes.

Should we also perhaps require the timezone to be UTC?

Related to projectatomic/atomic-reactor#116.
