### PR TITLE
Update tech-preview naming

### DIFF
--- a/vendor/redhat/names.md
+++ b/vendor/redhat/names.md
@@ -193,13 +193,11 @@ rhel8-beta/php...
 
 ## Tech Preview Releases
 
-Tech Preview releases are treated similarly to Beta. Example:
-
-```
-rhel8-tech-preview/rhel:$VERSION-$IMGBUILD
-rhel8-tech-preview/rhel-tools:$VERSION-$IMGBUILD
-...
-```
+Tech Preview releases are treated similarly to GA. 
+There need be no special signifier in the repoistory name that an
+image is tech preview, as the images (like rpms) are treated as GA 
+in terms of signing. Tech Preview status should be handled at the Documentation
+Level.
 
 ## Bugzilla Mapping
 

--- a/vendor/redhat/names.md
+++ b/vendor/redhat/names.md
@@ -194,7 +194,7 @@ rhel8-beta/php...
 ## Tech Preview Releases
 
 Tech Preview releases are treated similarly to GA. 
-There need be no special signifier in the repoistory name that an
+There need be no special signifier in the repository name that an
 image is tech preview, as the images (like rpms) are treated as GA 
 in terms of signing. Tech Preview status should be handled at the Documentation
 Level.


### PR DESCRIPTION
We are trying to move away from differentiating tech-preview at the repository level, this will help us move forward with container signing, and will keep our policies lined up with how we treat tech preview rpms.