### PR TITLE
Update Koji naming

### DIFF
--- a/vendor/redhat/names.md
+++ b/vendor/redhat/names.md
@@ -127,18 +127,18 @@ registry.access.redhat.com/rhscl/postgresql-92-rhel7:9.2-4
 
 The internal root of the naming is the naming of the dist-git repo that contains the Dockerfile. So that naming must follow the above schema (without the tagging as that will be handled automatically)
 
-dist-git repos should be named `$REPO-docker`.
+dist-git repos should be named `$REPO-container`.
 
 The product context is derived from koji.
 
 Exceptions:
 
-RHEL Server base images. Internal name is rhel-server-docker, external name is just rhel
+RHEL Server base images. Internal name is rhel-server-container, external name is just rhel
 
 Examples:
 
-rhel-server-docker -> rhel$MAJOR/rhel:TAG  
-rhel-tools-docker -> rhel$MAJOR/rhel-tools:TAG 
+rhel-server-container -> rhel$MAJOR/rhel:TAG  
+rhel-tools-container -> rhel$MAJOR/rhel-tools:TAG 
 
 ## Primary Product Images in library/
 

--- a/vendor/redhat/names.md
+++ b/vendor/redhat/names.md
@@ -208,13 +208,13 @@ REGISTRY/
  :$COMPVER-$IMGBUILD
 ```
 
-The mapping to Bugzilla (or Jira) components will follow REPO-docker within the respective product. Details as follows:
+The mapping to Bugzilla (or Jira) components will follow REPO-container within the respective product. Details as follows:
 
 
 * `REGISTRY` Ignored in Bugzilla
 * `PRODUCT[$PRODUCTGEN]` Maps to the product/version in Bugzilla, other metadata such as
 * `REPO[--$CONTENTGENERATION][--$PLATFORMDIFFERENTIATOR]`
-  * `REPO[--$CONTENTGENERATION]` maps to the component with -docker appended
+  * `REPO[--$CONTENTGENERATION]` maps to the component with -container appended
   * `PLATFORMDIFFERNTIATOR` is not part of the formal mapping
 * `:$COMPVER` Maps to the version of the component
 * `-$IMGBUILD` is not part of the formal mapping
@@ -229,7 +229,7 @@ maps to
 
 * Product: Red Hat Enterprise Linux 7
 * Version: 7.0
-* Component: php-docker
+* Component: php-container
 
 ## ISV Namespaces
 


### PR DESCRIPTION
The internal naming scheme has changed to replace _docker_ with _container_